### PR TITLE
Deployment: Dockerfile and Smithery config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Start with a base image containing Python 3.13
+FROM python:3.13-slim
+
+# Set environment variables for Python
+ENV PYTHONUNBUFFERED=1
+
+# Set work directory
+WORKDIR /app
+
+# Copy the necessary files
+COPY pyproject.toml /app/
+COPY src /app/src
+
+# Install dependencies
+RUN pip install --upgrade pip && \
+    pip install hatch && \
+    hatch build && \
+    pip install dist/*.whl
+
+# Expose any ports if needed (not specified in README, assumed none)
+# EXPOSE 8000
+
+# Command to run the server
+CMD ["python", "src/mcp_jira_python/server.py"]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,20 @@
 # MCP JIRA Python 🚀
 
+[![smithery badge](https://smithery.ai/badge/@Kallows/mcp-jira-python)](https://smithery.ai/go/@Kallows/mcp-jira-python)
+
 A Python implementation of a MCP server for JIRA integration. MCP is a communication protocol designed to provide tools to your AI and keep your data secure (and local if you like). The server runs on the same computer as your AI application and the Claude Desktop is the first application to run MCP Servers (and is considered a client. See the examples folder for a simple python MCP client).
 
 ## Installation
 
+### Installing via Smithery
+
+To install JIRA for Claude Desktop automatically via [Smithery](https://smithery.ai/go/@Kallows/mcp-jira-python):
+
+```bash
+npx -y @smithery/cli install @Kallows/mcp-jira-python --client claude
+```
+
+### Manual Installation
 ```bash
 # Install the server locally
 git clone https://github.com/kallows/mcp-jira-python.git 

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,25 @@
+# Smithery configuration file: https://smithery.ai/docs/deployments
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - jiraHost
+      - jiraEmail
+      - jiraApiToken
+    properties:
+      jiraHost:
+        type: string
+        description: Your JIRA instance's host, e.g., your-domain.atlassian.net
+      jiraEmail:
+        type: string
+        description: Your JIRA account email, e.g., your-email@example.com
+      jiraApiToken:
+        type: string
+        description: Your JIRA API token
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    config => ({command: 'python', args: ['src/mcp_jira_python/server.py'], env: {JIRA_HOST: config.jiraHost, JIRA_EMAIL: config.jiraEmail, JIRA_API_TOKEN: config.jiraApiToken}})


### PR DESCRIPTION
This pull request introduces the following updates:

- **Dockerfile**: Introduces a Dockerfile to package the MCP for deployment across various environments.
- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. This file is used by [Smithery](https://smithery.ai?utm_campaign=pr) to render configurations for the end-user. It also allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to Smithery, serving it over SSE so end-users do not need to install additional dependencies. You may deploy your server by visiting your [server page](https://smithery.ai/server/@Kallows/mcp-jira-python?utm_campaign=pr&modal=claim), claiming it and clicking "Deploy".
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. Note that the installation only works after the server is deployed.

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let us know if you have any questions. 🙂